### PR TITLE
Fix swig wrapping shared_ptr in director

### DIFF
--- a/swig/core.i
+++ b/swig/core.i
@@ -83,6 +83,8 @@
 %shared_ptr(kuzzleio::notification_result);
 %shared_ptr(kuzzleio::SearchResult);
 
+%typemap(csdirectorin) std::shared_ptr<kuzzleio::notification_result> "new NotificationResult($iminput, true)"
+
 %inline {
   namespace kuzzleio {
     class NotificationListenerClass {


### PR DESCRIPTION
## What does this PR do ?

Add a csdirector in on type `shared_ptr<kuzzleio::notification_result>` for swig to correctly wrap this shared_ptr inside a director (https://github.com/swig/swig/issues/419).
