### PR TITLE
Prevent premature garbage collection of Protocol objects

### DIFF
--- a/swig/core.i
+++ b/swig/core.i
@@ -136,16 +136,13 @@
 // Add a C# reference to prevent premature garbage collection and resulting use
 // of dangling C++ pointer.
 %typemap(cscode) kuzzleio::Kuzzle %{
-  // Ensure that the GC doesn't collect any Protocol instance set from C#
-  private Protocol _protocol;
-  internal void addReference(Protocol protocol) {
-    _protocol = protocol;
-  }
+  protected Protocol _protocol;
 %}
 
 %typemap(csconstruct, excode=SWIGEXCODE) Kuzzle %{: this($imcall, true)
   {$excode$directorconnect
-    this.addReference(protocol);
+    // Ensure that the GC doesn't collect any Protocol instance set from C#
+    _protocol = protocol;
   }
 %}
 

--- a/swig/core.i
+++ b/swig/core.i
@@ -131,6 +131,23 @@
   }
 }
 
+// Add a C# reference to prevent premature garbage collection and resulting use
+// of dangling C++ pointer.
+%typemap(cscode) kuzzleio::Kuzzle %{
+  // Ensure that the GC doesn't collect any Protocol instance set from C#
+  private Protocol _protocol;
+  internal void addReference(Protocol protocol) {
+    _protocol = protocol;
+  }
+%}
+
+%typemap(csconstruct, excode=SWIGEXCODE) Kuzzle %{: this($imcall, true)
+  {$excode$directorconnect
+    this.addReference(protocol);
+  }
+%}
+
+
 %{
 #include "kuzzle.cpp"
 #include "realtime.cpp"


### PR DESCRIPTION
# Description

When instantiating a class inheriting the Protocol abstract (WebSocket or any custom protocol), and passing it to the Kuzzle C# constructor, if a reference to the protocol instance is not kept alongside the kuzzle one, then it is garbage collected at the first opportunity.
This triggers a proper call to the C++ Protocol destructor, closing network and memory resources... but the Kuzzle C++ class still uses those, and this ends in a crash because of dangling C++ pointers.

This is because while the Kuzzle class in the C++ layer keeps a pointer to the protocol instance, the corresponding C# Kuzzle class does not. And obviously, the C# garbage collector cannot know that the protocol class instance is still being used in the C++ layer.

This PR configures the SWIG-generated Kuzzle class to force-keep a reference to the protocol instance it receives in a seemingly useless protected class member.