### PR TITLE
Prevent premature garbage collection of notification listeners

### DIFF
--- a/swig/core.i
+++ b/swig/core.i
@@ -150,9 +150,11 @@
           >();
 
   internal void addListener(string roomId, NotificationListener listener) {
-    _listeners.TryAdd(
-      roomId,
-      new System.Collections.Concurrent.ConcurrentBag<NotificationListener>());
+    if (!_listeners.ContainsKey(roomId)) {
+      _listeners.TryAdd(
+        roomId,
+        new System.Collections.Concurrent.ConcurrentBag<NotificationListener>());
+    }
 
     _listeners[roomId].Add(listener);
   }

--- a/swig/core.i
+++ b/swig/core.i
@@ -136,16 +136,13 @@
 // Add a C# reference to prevent premature garbage collection and resulting use
 // of dangling C++ pointer.
 %typemap(cscode) kuzzleio::Kuzzle %{
-  // Ensure that the GC doesn't collect any Protocol instance set from C#
-  private Protocol _protocol;
-  internal void addReference(Protocol protocol) {
-    _protocol = protocol;
-  }
+  protected Protocol _protocol;
 %}
 
 %typemap(csconstruct, excode=SWIGEXCODE) Kuzzle %{: this($imcall, true)
   {$excode$directorconnect
-    this.addReference(protocol);
+    // Ensure that the GC doesn't collect any Protocol instance set from C#
+    _protocol = protocol;
   }
 %}
 

--- a/swig/core.i
+++ b/swig/core.i
@@ -131,6 +131,23 @@
   }
 }
 
+// Add a C# reference to prevent premature garbage collection and resulting use
+// of dangling C++ pointer.
+%typemap(cscode) kuzzleio::Kuzzle %{
+  // Ensure that the GC doesn't collect any Protocol instance set from C#
+  private Protocol _protocol;
+  internal void addReference(Protocol protocol) {
+    _protocol = protocol;
+  }
+%}
+
+%typemap(csconstruct, excode=SWIGEXCODE) Kuzzle %{: this($imcall, true)
+  {$excode$directorconnect
+    this.addReference(protocol);
+  }
+%}
+
+
 %{
 #include "kuzzle.cpp"
 #include "realtime.cpp"


### PR DESCRIPTION
# Description

* Prevent premature garbage collection of notification listeners by keeping a reference to the `NotificationListener` instance in the `Realtime` controller, until a call to `unsubscribe` is performed on the corresponding room identifier (see #8 for detailed information)
* Make all Kuzzle controllers singletons, instead of recreating a new instance each time they are called. This is necessary for the item just above
* Hide internal versions of the `subscribe` and `unsubscribe` methods, to avoid confusion when using an IDE