### PR TITLE
Deploy the nuget package automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: csharp
 solution: sdk-csharp.sln
+mono: none
+dotnet: 2.2.203
 install:
-  - nuget restore sdk-csharp.sln
+  - dotnet restore
 
 script:
   - dotnet build Kuzzle/Kuzzle.csproj -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: csharp
+solution: sdk-csharp.sln
+install:
+  - nuget restore sdk-csharp.sln
+
+script:
+  - dotnet build Kuzzle/Kuzzle.csproj -c Release
+
+deploy:
+  skip_cleanup: true
+  provider: script
+  email: support@kuzzle.io
+  script:
+    - nuget pack Kuzzle/Kuzzle.nuspec -OutputFileNamesWithoutVersion
+    - nuget push kuzzlesdk.nupkg -ApiKey ${NUGET_API_KEY} -Source nuget.org
+  on:
+    repo: kuzzleio/sdk-csharp
+    all_branches: true
+    condition: $TRAVIS_BRANCH = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: csharp
 solution: sdk-csharp.sln
 sudo: required
+dist: xenial
 mono: none
 dotnet: 2.2
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: csharp
 solution: sdk-csharp.sln
+sudo: required
 mono: none
-dotnet: 2.2.203
+dotnet: 2.2
 install:
   - dotnet restore
 

--- a/Kuzzle/Kuzzle.nuspec
+++ b/Kuzzle/Kuzzle.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>kuzzlesdk</id>
     <title>Kuzzle SDK</title>
-    <version>0.1.12</version>
+    <version>0.1.13</version>
     <authors>Kuzzle Team</authors>
     <owners>Kuzzle Team</owners>
     <license type="expression">Apache-2.0</license>

--- a/Kuzzle/Kuzzle.nuspec
+++ b/Kuzzle/Kuzzle.nuspec
@@ -6,8 +6,8 @@
     <version>0.1.12</version>
     <authors>Kuzzle Team</authors>
     <owners>Kuzzle Team</owners>
+    <license type="expression">Apache-2.0</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <licenseUrl>https://github.com/kuzzleio/sdk-csharp/LICENSE</licenseUrl>
     <projectUrl>https://github.com/kuzzleio/sdk-csharp</projectUrl>
     <description>Official C# SDK for Kuzzle</description>
     <dependencies>
@@ -15,6 +15,7 @@
         <dependency id="Newtonsoft.Json" version="12.0.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>
+    <iconUrl>https://raw.githubusercontent.com/kuzzleio/sdk-csharp/master/Kuzzle/package_icon.png</iconUrl>
   </metadata>
   <files>
     <file src="bin/Release/netstandard2.0/Kuzzle.dll" target="lib/netstandard2.0/Kuzzle.dll" />


### PR DESCRIPTION
# Description

Add a travis configuration to make it automatically deploy the updated nuget package on nuget.org

Also fix the nuget configuration file to use a proper Kuzzle logo in the package directory, and with the right, non-deprecated license declaration.