### PR TITLE
Add unit test for Realtime Controller 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 build/
 packages/
-.vs/
+.vscode/
 
 */bin/
 */obj/

--- a/Kuzzle.Tests/API/Controllers/RealtimeControllerTest.cs
+++ b/Kuzzle.Tests/API/Controllers/RealtimeControllerTest.cs
@@ -63,7 +63,10 @@ namespace Kuzzle.Tests.API.Controllers
         }
 
         [Theory]
-        [ClassData(typeof(SubscribeOptionGenerator))]
+        [
+            MemberData(nameof(MockGenerators.GenerateSubscribeOptions),
+            MemberType = typeof(MockGenerators))
+        ]
         public async void SubscribeAsyncTest(SubscribeOptions options)
         {
             string roomId = "A113";
@@ -125,21 +128,6 @@ namespace Kuzzle.Tests.API.Controllers
                 {"action", "unsubscribe"},
                 {"body", new JObject {{ "roomId", roomId}}}
             });
-        }
-    }
-
-    public class SubscribeOptionGenerator : TheoryData<SubscribeOptions>
-    {
-        public SubscribeOptionGenerator()
-        {
-            SubscribeOptions s = new SubscribeOptions();
-            Add(s);
-
-            SubscribeOptions s1 = new SubscribeOptions();
-            s1.Volatile = new JObject { { "reason", "test purpose" } };
-            Add(s1);
-
-            Add(null);
         }
     }
 }

--- a/Kuzzle.Tests/API/Controllers/RealtimeControllerTest.cs
+++ b/Kuzzle.Tests/API/Controllers/RealtimeControllerTest.cs
@@ -1,0 +1,145 @@
+using KuzzleSdk.API.Controllers;
+using Xunit;
+using Newtonsoft.Json.Linq;
+using System;
+using KuzzleSdk.API.Options;
+using KuzzleSdk.API;
+
+namespace Kuzzle.Tests.API.Controllers
+{
+    public class RealtimeControllerTest
+    {
+        private readonly RealtimeController _realtimeController;
+        private readonly KuzzleApiMock _api;
+
+        public RealtimeControllerTest()
+        {
+            _api = new KuzzleApiMock();
+            _realtimeController = new RealtimeController(_api.MockedObject);
+        }
+
+        private void MockNotificationHandler(Response notification)
+        {
+            Console.WriteLine(notification.Result);
+        }
+
+        [Fact]
+        public async void CountAsyncTest()
+        {
+            string roomId = "A113";
+            Int32 count = 3;
+            _api.SetResult(new JObject { {
+                "result", new JObject { {
+                    "count", count } }
+                } }
+            );
+
+            Int32 res = await _realtimeController.CountAsync(roomId);
+
+            _api.Verify(new JObject {
+                { "controller", "realtime" },
+                { "action", "count" },
+                { "body", new JObject {{ "roomId", roomId }}}
+            });
+            Assert.Equal<Int32>(count, res);
+        }
+
+        [Fact]
+        public async void PublishAsyncTest()
+        {
+            string index = "an_index";
+            string collection = "to";
+            JObject message = new JObject { { "infinity", "and beyond" } };
+
+            await _realtimeController.PublishAsync(index, collection, message);
+
+            _api.Verify(new JObject{
+                {"index" , index },
+                {"collection" , collection },
+                {"controller" , "realtime" },
+                {"action" ,"publish" },
+                {"body" , message },
+            });
+        }
+
+        [Theory]
+        [ClassData(typeof(SubscribeOptionGenerator))]
+        public async void SubscribeAsyncTest(SubscribeOptions options)
+        {
+            string roomId = "A113";
+            string channel = "a_channel";
+            _api.SetResult(new JObject { {
+                "result", new JObject {
+                    { "roomId", roomId },
+                    { "channel", channel } }
+                } }
+            );
+            string index = "an_index";
+            string collection = "a_collection";
+            JObject filters = new JObject { { "studio", "pixar" } };
+            JObject expectedQuery = new JObject {
+                {"index", index},
+                {"collection",collection},
+                {"controller", "realtime"},
+                {"action", "subscribe"},
+                {"body", filters}
+            };
+            if (options != null)
+            {
+                expectedQuery.Merge(JObject.FromObject(options));
+            }
+
+            string res = await _realtimeController.SubscribeAsync(index, collection, filters, MockNotificationHandler, options);
+
+            _api.Verify(expectedQuery);
+            Assert.Equal(roomId, res);
+        }
+
+        [Fact]
+        public async void UnsubscribeAsyncTest()
+        {
+            //First we need to subscribe to "a_collection"
+            string index = "an_index";
+            string collection = "a_collection";
+            JObject filters = new JObject { { "studio", "pixar" } };
+            string roomId = "A113";
+            string channel = "a_channel";
+            _api.SetResult(new JObject { {
+                "result", new JObject {
+                    { "roomId", roomId },
+                    { "channel", channel } }
+                } }
+            );
+            await _realtimeController.SubscribeAsync(index, collection, filters, MockNotificationHandler);
+
+            //Then we can test if unsubcription is working
+            _api.SetResult(new JObject {{
+                "result",  new JObject {{ "roomId", roomId }}
+                }}
+            );
+
+            await _realtimeController.UnsubscribeAsync(roomId);
+
+            _api.Verify(new JObject {
+                {"controller", "realtime"},
+                {"action", "unsubscribe"},
+                {"body", new JObject {{ "roomId", roomId}}}
+            });
+        }
+    }
+
+    public class SubscribeOptionGenerator : TheoryData<SubscribeOptions>
+    {
+        public SubscribeOptionGenerator()
+        {
+            SubscribeOptions s = new SubscribeOptions();
+            Add(s);
+
+            SubscribeOptions s1 = new SubscribeOptions();
+            s1.Volatile = new JObject { { "reason", "test purpose" } };
+            Add(s1);
+
+            Add(null);
+        }
+    }
+}

--- a/Kuzzle.Tests/API/Controllers/RealtimeControllerTest.cs
+++ b/Kuzzle.Tests/API/Controllers/RealtimeControllerTest.cs
@@ -88,9 +88,9 @@ namespace Kuzzle.Tests.API.Controllers
             {
                 expectedQuery.Merge(JObject.FromObject(options));
             }
-            Mock<RealtimeController.NotificationHandler> mockNotifHand = new Mock<RealtimeController.NotificationHandler>();
+            Mock<RealtimeController.NotificationHandler> notificationHandlerMock = new Mock<RealtimeController.NotificationHandler>();
 
-            string res = await _realtimeController.SubscribeAsync(index, collection, filters, mockNotifHand.Object, options);
+            string res = await _realtimeController.SubscribeAsync(index, collection, filters, notificationHandlerMock.Object, options);
 
             _api.Verify(expectedQuery);
             Assert.Equal(roomId, res);
@@ -111,9 +111,9 @@ namespace Kuzzle.Tests.API.Controllers
                     { "channel", channel } }
                 } }
             );
-            Mock<RealtimeController.NotificationHandler> mockNotifHand = new Mock<RealtimeController.NotificationHandler>();
+            Mock<RealtimeController.NotificationHandler> notificationHandlerMock = new Mock<RealtimeController.NotificationHandler>();
 
-            await _realtimeController.SubscribeAsync(index, collection, filters, mockNotifHand.Object);
+            await _realtimeController.SubscribeAsync(index, collection, filters, notificationHandlerMock.Object);
 
             //Then we test that Notification Handler is not called after the unsubscription. 
             _api.SetResult(new JObject {{
@@ -130,7 +130,7 @@ namespace Kuzzle.Tests.API.Controllers
 
             Response notif = Response.FromString("{room: 'a_channel'}");
             _api.Mock.Raise(m => m.UnhandledResponse += null, this, notif);
-            mockNotifHand.Verify(m => m.Invoke(notif), Times.Never);
+            notificationHandlerMock.Verify(m => m.Invoke(notif), Times.Never);
         }
 
         [Fact]
@@ -154,15 +154,15 @@ namespace Kuzzle.Tests.API.Controllers
                     { "channel", "a_channel"} }
                 } }
             );
-            Mock<RealtimeController.NotificationHandler> mockNotifHand = new Mock<RealtimeController.NotificationHandler>();
-            await _realtimeController.SubscribeAsync(index, collection, filters, mockNotifHand.Object);
+            Mock<RealtimeController.NotificationHandler> notificationHandlerMock = new Mock<RealtimeController.NotificationHandler>();
+            await _realtimeController.SubscribeAsync(index, collection, filters, notificationHandlerMock.Object);
 
             //Then we trigger a notification
             Response notif = Response.FromString("{room: 'a_channel'}");
             _api.Mock.Raise(m => m.UnhandledResponse += null, this, notif);
 
             //Then we can check that the handler has been called
-            mockNotifHand.Verify(m => m.Invoke(notif), Times.AtLeastOnce);
+            notificationHandlerMock.Verify(m => m.Invoke(notif), Times.AtLeastOnce);
         }
 
         public static IEnumerable<object[]> SubscribeOptionsData()

--- a/Kuzzle.Tests/API/KuzzleApiMock.cs
+++ b/Kuzzle.Tests/API/KuzzleApiMock.cs
@@ -20,7 +20,7 @@ namespace Kuzzle.Tests.API {
     }
 
     public KuzzleApiMock() {
-      Mock = new Mock<IKuzzleApi>();
+      Mock = new Mock<IKuzzleApi> { DefaultValue = DefaultValue.Mock };
     }
 
     public void SetResult(JToken apiResult) {

--- a/Kuzzle/API/Controllers/RealtimeController.cs
+++ b/Kuzzle/API/Controllers/RealtimeController.cs
@@ -88,7 +88,7 @@ namespace KuzzleSdk.API.Controllers {
       rooms.Remove(room);
     }
 
-    internal RealtimeController(Kuzzle k) : base(k) {
+    internal RealtimeController(IKuzzleApi api) : base(api) {
       api.UnhandledResponse += NotificationsListener;
       api.NetworkProtocol.StateChanged += StateChangeListener;
       api.TokenExpired += TokenExpiredListener;
@@ -113,8 +113,7 @@ namespace KuzzleSdk.API.Controllers {
         { "action", "count" },
         { "body", new JObject{ { "roomId", roomId } } }
       });
-
-      return (int)response.Result;
+      return (int)response.Result["count"];
     }
 
     /// <summary>


### PR DESCRIPTION
## What does this PR do ?
Add unit test for realtime controller. 

### Other changes
- Fix error on Count function : It should return the `count` attribute of the result
- Fix mocking error : The `IKuzzleAPI` interface contains objects (like `NetworkProtocol`) that should be mocked. To mock recursively, i added the option in the creation of the mock.  