### PR TITLE
Rewrite WebSocket class

### DIFF
--- a/.ci/doc/templates/default.tpl.cs
+++ b/.ci/doc/templates/default.tpl.cs
@@ -1,12 +1,13 @@
 #r "Kuzzle.dll"
 using System;
-using KuzzleSdk;
-using KuzzleSdk.API;
-using KuzzleSdk.Protocol;
+using System.Threading;
 using System.Threading.Tasks;
+using KuzzleSdk;
+using KuzzleSdk.Protocol;
 
-KuzzleSdk.Kuzzle kuzzle = new KuzzleSdk.Kuzzle(new WebSocket("kuzzle"));
+WebSocket socket = new WebSocket(new Uri("ws://kuzzle:7512"));
+KuzzleSdk.Kuzzle kuzzle = new KuzzleSdk.Kuzzle(socket);
 
-await kuzzle.ConnectAsync();
+kuzzle.ConnectAsync(CancellationToken.None).Wait();
 
 [snippet-code]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 packages/
 .vscode/
+.vs/
 
 */bin/
 */obj/

--- a/Kuzzle.Tests/Kuzzle.Tests.csproj
+++ b/Kuzzle.Tests/Kuzzle.Tests.csproj
@@ -27,5 +27,6 @@
   <ItemGroup>
     <Folder Include="API\" />
     <Folder Include="API\Controllers\" />
+    <Folder Include="Protocol\" />
   </ItemGroup>
 </Project>

--- a/Kuzzle.Tests/KuzzleTest.cs
+++ b/Kuzzle.Tests/KuzzleTest.cs
@@ -7,6 +7,7 @@ using KuzzleSdk.API.Controllers;
 using System;
 using System.Threading.Tasks;
 using Moq;
+using System.Threading;
 
 namespace Kuzzle.Tests {
   public class KuzzleTest {
@@ -22,7 +23,7 @@ namespace Kuzzle.Tests {
     public void DispatchTokenExpiredTest() {
       _kuzzle.AuthenticationToken = "token";
       bool eventDispatched = false;
-      _kuzzle.TokenExpired += delegate() {
+      _kuzzle.TokenExpired += delegate () {
         eventDispatched = true;
       };
 
@@ -46,9 +47,9 @@ namespace Kuzzle.Tests {
 
     [Fact]
     public async void ConnectAsyncTest() {
-      await _kuzzle.ConnectAsync();
+      await _kuzzle.ConnectAsync(CancellationToken.None);
 
-      _protocol.Verify(m => m.ConnectAsync(), Times.Once);
+      _protocol.Verify(m => m.ConnectAsync(CancellationToken.None), Times.Once);
     }
 
     [Fact]
@@ -98,7 +99,7 @@ namespace Kuzzle.Tests {
 
       Assert.Single(_kuzzle.requests);
     }
-    private bool testSendArg (JObject request) {
+    private bool testSendArg(JObject request) {
       Assert.Equal("test", request["controller"]);
       Assert.Equal("testAction", request["action"]);
       Assert.Equal("jwt auth token", request["jwt"]);
@@ -134,7 +135,7 @@ namespace Kuzzle.Tests {
     [Fact]
     public async void ResponseListenerTokenExpiredTest() {
       bool eventDispatched = false;
-      _kuzzle.TokenExpired += delegate() {
+      _kuzzle.TokenExpired += delegate () {
         eventDispatched = true;
       };
       TaskCompletionSource<Response> responseTask =
@@ -165,7 +166,7 @@ namespace Kuzzle.Tests {
     [Fact]
     public void ResponseListenerUnhandledTest() {
       bool eventDispatched = false;
-      _kuzzle.UnhandledResponse += delegate(object sender, Response response) {
+      _kuzzle.UnhandledResponse += delegate (object sender, Response response) {
         eventDispatched = true;
 
         Assert.Equal("i am the result", response.Result);
@@ -184,7 +185,7 @@ namespace Kuzzle.Tests {
     }
 
     [Fact]
-    public async void StateChangeListenerTest () {
+    public async void StateChangeListenerTest() {
       TaskCompletionSource<Response> responseTask1 =
         new TaskCompletionSource<Response>();
       TaskCompletionSource<Response> responseTask2 =

--- a/Kuzzle.Tests/Protocol/WebSocketTest.cs
+++ b/Kuzzle.Tests/Protocol/WebSocketTest.cs
@@ -94,14 +94,15 @@ namespace Kuzzle.Tests.Protocol {
       _ws.MockSocket.Verify(s => s.Abort(), Times.Once);
     }
 
-    [Fact(Skip = "oh noes")]
+    [Fact]
     public void DisconnectWithoutEverConnecting() {
+      Assert.Equal(ProtocolState.Closed, _ws.State);
+      Assert.Equal(0, _ws.StateChangesCount);
+
       _ws.Disconnect();
 
       Assert.Equal(ProtocolState.Closed, _ws.State);
       Assert.Equal(0, _ws.StateChangesCount);
-
-      _ws.MockSocket.Verify(s => s.Abort(), Times.Never);
     }
   }
 }

--- a/Kuzzle.Tests/Protocol/WebSocketTest.cs
+++ b/Kuzzle.Tests/Protocol/WebSocketTest.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading;
+using KuzzleSdk.Protocol;
+using Moq;
+using Xunit;
+
+namespace Kuzzle.Tests.Protocol {
+  public class TestableWebSocket : WebSocket {
+    public bool SocketCreated { get; private set; } = false;
+
+    public TestableWebSocket(Uri uri) : base(uri) { }
+
+    internal override dynamic CreateClientSocket() {
+      SocketCreated = true;
+      return new Mock<IClientWebSocket>();
+    }
+  }
+
+  public class WebSocketTest {
+    private readonly TestableWebSocket _ws;
+    private readonly Uri uri;
+
+    public WebSocketTest() {
+      uri = new Uri(@"ws://foo:1234");
+      _ws = new TestableWebSocket(uri);
+    }
+
+    [Fact]
+    public void ConstructorNotConnected() {
+      var ws = new TestableWebSocket(uri);
+
+      Assert.Equal(ProtocolState.Closed, ws.State);
+      Assert.False(ws.SocketCreated);
+    }
+
+    [Fact]
+    public void ConstructorRejectsNullUri() {
+      Assert.Throws<ArgumentNullException>(() => new TestableWebSocket(null));
+    }
+
+    [Fact]
+    public async void ConnectAsyncTest() {
+      await _ws.ConnectAsync(CancellationToken.None);
+
+      Assert.True(_ws.SocketCreated);
+      Mock.Verify(_ws => _ws.ConnectAsync(uri, CancellationToken.None);
+    }
+  }
+}

--- a/Kuzzle.Tests/Protocol/WebSocketTest.cs
+++ b/Kuzzle.Tests/Protocol/WebSocketTest.cs
@@ -1,18 +1,34 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using KuzzleSdk.Protocol;
 using Moq;
 using Xunit;
 
 namespace Kuzzle.Tests.Protocol {
   public class TestableWebSocket : WebSocket {
-    public bool SocketCreated { get; private set; } = false;
+    internal Mock<IClientWebSocket> MockSocket;
+    public int StateChangesCount = 0;
+    public ProtocolState LastStateDispatched = ProtocolState.Closed;
 
-    public TestableWebSocket(Uri uri) : base(uri) { }
+    public TestableWebSocket(Uri uri) : base(uri) {
+      StateChanged += (sender, e) => {
+        StateChangesCount++;
+        LastStateDispatched = e;
+      };
+    }
 
     internal override dynamic CreateClientSocket() {
-      SocketCreated = true;
-      return new Mock<IClientWebSocket>();
+      MockSocket = new Mock<IClientWebSocket>();
+
+      MockSocket
+        .Setup(s => s.ConnectAsync(
+          It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+        .Returns(Task.CompletedTask);
+
+      MockSocket.Object.State = System.Net.WebSockets.WebSocketState.Open;
+
+      return MockSocket.Object;
     }
   }
 
@@ -30,7 +46,7 @@ namespace Kuzzle.Tests.Protocol {
       var ws = new TestableWebSocket(uri);
 
       Assert.Equal(ProtocolState.Closed, ws.State);
-      Assert.False(ws.SocketCreated);
+      Assert.Null(ws.socket);
     }
 
     [Fact]
@@ -42,8 +58,50 @@ namespace Kuzzle.Tests.Protocol {
     public async void ConnectAsyncTest() {
       await _ws.ConnectAsync(CancellationToken.None);
 
-      Assert.True(_ws.SocketCreated);
-      Mock.Verify(_ws => _ws.ConnectAsync(uri, CancellationToken.None);
+      Assert.NotNull(_ws.socket);
+
+      await _ws.ConnectAsync(CancellationToken.None);
+      await _ws.ConnectAsync(CancellationToken.None);
+      await _ws.ConnectAsync(CancellationToken.None);
+
+      _ws.MockSocket.Verify(
+        s => s.ConnectAsync(uri, CancellationToken.None),
+        Times.Once);
+
+      Assert.Equal(ProtocolState.Open, _ws.State);
+      Assert.Equal(1, _ws.StateChangesCount);
+      Assert.Equal(ProtocolState.Open, _ws.LastStateDispatched);
+    }
+
+    [Fact]
+    public async void DisconnectTest() {
+      await _ws.ConnectAsync(CancellationToken.None);
+
+      Assert.Equal(ProtocolState.Open, _ws.State);
+      Assert.Equal(1, _ws.StateChangesCount);
+      Assert.Equal(ProtocolState.Open, _ws.LastStateDispatched);
+
+      _ws.Disconnect();
+      _ws.Disconnect();
+      _ws.Disconnect();
+
+      Assert.Equal(ProtocolState.Closed, _ws.State);
+
+      // we should only get 1 state change
+      Assert.Equal(2, _ws.StateChangesCount);
+      Assert.Equal(ProtocolState.Closed, _ws.LastStateDispatched);
+
+      _ws.MockSocket.Verify(s => s.Abort(), Times.Once);
+    }
+
+    [Fact(Skip = "oh noes")]
+    public void DisconnectWithoutEverConnecting() {
+      _ws.Disconnect();
+
+      Assert.Equal(ProtocolState.Closed, _ws.State);
+      Assert.Equal(0, _ws.StateChangesCount);
+
+      _ws.MockSocket.Verify(s => s.Abort(), Times.Never);
     }
   }
 }

--- a/Kuzzle/Kuzzle.cs
+++ b/Kuzzle/Kuzzle.cs
@@ -11,6 +11,9 @@ using System.Threading;
 
 [assembly: InternalsVisibleTo("Kuzzle.Tests")]
 
+// Allow using Moq on internal objects/interfaces
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+
 namespace KuzzleSdk {
   /// <summary>
   /// Kuzzle API interface.
@@ -248,7 +251,7 @@ namespace KuzzleSdk {
     /// <returns>API response</returns>
     /// <param name="query">Kuzzle API query</param>
     public Task<Response> QueryAsync(JObject query) {
-      if (query == null){
+      if (query == null) {
         throw new Exceptions.InternalException("You must provide a query", 400);
       }
 

--- a/Kuzzle/Kuzzle.cs
+++ b/Kuzzle/Kuzzle.cs
@@ -7,6 +7,7 @@ using KuzzleSdk.API.Controllers;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 [assembly: InternalsVisibleTo("Kuzzle.Tests")]
 
@@ -229,8 +230,8 @@ namespace KuzzleSdk {
     /// <summary>
     /// Establish a network connection
     /// </summary>
-    public async Task ConnectAsync() {
-      await NetworkProtocol.ConnectAsync();
+    public async Task ConnectAsync(CancellationToken cancellationToken) {
+      await NetworkProtocol.ConnectAsync(cancellationToken);
     }
 
     /// <summary>

--- a/Kuzzle/Kuzzle.csproj
+++ b/Kuzzle/Kuzzle.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="API\Options\DocumentOptions.cs" />

--- a/Kuzzle/Protocol/AbstractProtocol.cs
+++ b/Kuzzle/Protocol/AbstractProtocol.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 

--- a/Kuzzle/Protocol/AbstractProtocol.cs
+++ b/Kuzzle/Protocol/AbstractProtocol.cs
@@ -20,7 +20,7 @@ namespace KuzzleSdk.Protocol {
     /// <summary>
     /// Connect this instance.
     /// </summary>
-    public abstract Task ConnectAsync();
+    public abstract Task ConnectAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Disconnect this instance.

--- a/Kuzzle/Protocol/WebSocket.cs
+++ b/Kuzzle/Protocol/WebSocket.cs
@@ -32,8 +32,8 @@ namespace KuzzleSdk.Protocol {
   public class WebSocket : AbstractProtocol {
     private const int receiveBufferSize = 64 * 1024;
     private const int sendBufferSize = 8 * 1024;
+    internal dynamic socket;
     private readonly Uri uri;
-    private IClientWebSocket socket;
     private CancellationTokenSource receiveCancellationToken;
     private CancellationTokenSource sendCancellationToken;
     private ArraySegment<byte> incomingBuffer =
@@ -46,7 +46,6 @@ namespace KuzzleSdk.Protocol {
       var s = new ClientWebSocket();
 
       s.Options.SetBuffer(receiveBufferSize, sendBufferSize);
-
       return s;
     }
 
@@ -86,7 +85,6 @@ namespace KuzzleSdk.Protocol {
     /// Disconnects this instance.
     /// </summary>
     public override void Disconnect() {
-      socket?.Abort();
       CloseState();
     }
 
@@ -153,6 +151,8 @@ namespace KuzzleSdk.Protocol {
 
     private void CloseState() {
       if (State != ProtocolState.Closed) {
+        socket.Abort();
+        socket = null;
         State = ProtocolState.Closed;
         DispatchStateChange(State);
         receiveCancellationToken?.Cancel();

--- a/Kuzzle/Protocol/WebSocket.cs
+++ b/Kuzzle/Protocol/WebSocket.cs
@@ -54,6 +54,7 @@ namespace KuzzleSdk.Protocol {
       State = ProtocolState.Open;
       DispatchStateChange(State);
 
+      Dequeue();
       Listen();
     }
 

--- a/Kuzzle/Protocol/WebSocket.cs
+++ b/Kuzzle/Protocol/WebSocket.cs
@@ -87,7 +87,7 @@ namespace KuzzleSdk.Protocol {
             true,
             sendCancellationToken.Token);
         }
-      }, sendCancellationToken.Token);
+      }, CancellationToken.None);
     }
 
     private void Listen() {
@@ -124,7 +124,7 @@ namespace KuzzleSdk.Protocol {
         }
 
         CloseState();
-      }, receiveCancellationToken.Token);
+      }, CancellationToken.None);
     }
 
     private void CloseState() {

--- a/Kuzzle/Protocol/WebSocket.cs
+++ b/Kuzzle/Protocol/WebSocket.cs
@@ -12,7 +12,7 @@ namespace KuzzleSdk.Protocol {
   /// our WebSocket class testable via duck typing.
   /// </summary>
   internal interface IClientWebSocket {
-    WebSocketState State { get; }
+    WebSocketState State { get; set; }
 
     Task ConnectAsync(Uri uri, CancellationToken cancellationToken);
     Task SendAsync(

--- a/Kuzzle/Protocol/WebSocket.cs
+++ b/Kuzzle/Protocol/WebSocket.cs
@@ -15,7 +15,6 @@ namespace KuzzleSdk.Protocol {
     private const int sendBufferSize = 8 * 1024;
     private readonly Uri uri;
     private readonly ClientWebSocket socket;
-    private readonly CancellationToken connectTimeout;
     private CancellationTokenSource receiveCancellationToken;
     private CancellationTokenSource sendCancellationToken;
     private ArraySegment<byte> incomingBuffer =
@@ -29,10 +28,8 @@ namespace KuzzleSdk.Protocol {
     /// <see cref="T:KuzzleSdk.Protocol.WebSocket"/> class.
     /// </summary>
     /// <param name="uri">URI pointing to a Kuzzle endpoint.</param>
-    /// <param name="cancellationToken">Connection cancellation token</param>
-    public WebSocket(Uri uri, CancellationToken cancellationToken) {
+    public WebSocket(Uri uri) {
       this.uri = uri ?? throw new ArgumentNullException(nameof(uri));
-      connectTimeout = cancellationToken;
       State = ProtocolState.Closed;
       socket = new ClientWebSocket();
       socket.Options.SetBuffer(receiveBufferSize, sendBufferSize);
@@ -41,7 +38,10 @@ namespace KuzzleSdk.Protocol {
     /// <summary>
     /// Connects to a Kuzzle server.
     /// </summary>
-    public override async Task ConnectAsync() {
+    /// <param name="cancellationToken">Connection cancellation token</param>
+    public override async Task ConnectAsync(
+      CancellationToken cancellationToken
+    ) {
       if (
         socket.State == WebSocketState.Connecting ||
         socket.State == WebSocketState.Open
@@ -49,7 +49,7 @@ namespace KuzzleSdk.Protocol {
         return;
       }
 
-      await socket.ConnectAsync(uri, connectTimeout);
+      await socket.ConnectAsync(uri, cancellationToken);
 
       State = ProtocolState.Open;
       DispatchStateChange(State);

--- a/Kuzzle/Protocol/WebSocket.cs
+++ b/Kuzzle/Protocol/WebSocket.cs
@@ -78,7 +78,7 @@ namespace KuzzleSdk.Protocol {
 
       Task.Run(async () => {
         while (socket.State == WebSocketState.Open) {
-          var payload = sendQueue.Take();
+          var payload = sendQueue.Take(sendCancellationToken.Token);
           var buffer = Encoding.UTF8.GetBytes(payload.ToString());
 
           await socket.SendAsync(

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/kuzzleio/sdk-csharp.svg?branch=master)](https://travis-ci.org/kuzzleio/kuzzle)
+[![Build Status](https://travis-ci.org/kuzzleio/sdk-csharp.svg?branch=master)](https://travis-ci.org/kuzzleio/sdk-csharp)
 [![codecov.io](http://codecov.io/github/kuzzleio/sdk-csharp/coverage.svg?branch=master)](http://codecov.io/github/kuzzleio/sdk-csharp?branch=master)
 [![Join the chat at https://gitter.im/kuzzleio/kuzzle](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/kuzzleio/kuzzle?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
## What does this PR do ?
The WebSocket protocol class has been rewritten. 
Before this PR a new SDK instance was create like this:
```cs
KuzzleSdk.Kuzzle kuzzle = new KuzzleSdk.Kuzzle(new WebSocket("kuzzle"));
await kuzzle.ConnectAsync();
```
now this can be done like this:
```cs
KuzzleSdk.Kuzzle kuzzle = new KuzzleSdk.Kuzzle(new WebSocket(new Uri("ws://kuzzle:7512")));
kuzzle.ConnectAsync(CancellationToken.None).Wait();
```

### How should this be manually tested?

Run unit tests

### Other changes

* Add unit tests.
* Fix documentation tests template.
