### PR TITLE
Configure an awaiter on tasks returned by QueryAsync

### DIFF
--- a/Kuzzle.Tests/API/Controllers/RealtimeControllerTest.cs
+++ b/Kuzzle.Tests/API/Controllers/RealtimeControllerTest.cs
@@ -8,168 +8,155 @@ using KuzzleSdk.API.Options;
 using KuzzleSdk.API;
 using Moq;
 
-namespace Kuzzle.Tests.API.Controllers
-{
-    public class RealtimeControllerTest
-    {
-        private readonly RealtimeController _realtimeController;
-        private readonly KuzzleApiMock _api;
+namespace Kuzzle.Tests.API.Controllers {
+  public class RealtimeControllerTest {
+    private readonly RealtimeController _realtimeController;
+    private readonly KuzzleApiMock _api;
 
-        public RealtimeControllerTest()
-        {
-            _api = new KuzzleApiMock();
-            _realtimeController = new RealtimeController(_api.MockedObject);
-        }
+    public RealtimeControllerTest() {
+      _api = new KuzzleApiMock();
+      _realtimeController = new RealtimeController(_api.MockedObject);
+    }
 
-        [Fact]
-        public async void CountAsyncTest()
-        {
-            string roomId = "A113";
-            Int32 count = 3;
-            _api.SetResult(new JObject { {
-                "result", new JObject { {
-                    "count", count } }
-                } }
-            );
+    [Fact]
+    public async void CountAsyncTest() {
+      string roomId = "A113";
+      Int32 count = 3;
+      _api.SetResult(new JObject {
+        { "result", new JObject { { "count", count } } }
+      });
 
-            Int32 res = await _realtimeController.CountAsync(roomId);
+      Int32 res = await _realtimeController.CountAsync(roomId);
 
-            _api.Verify(new JObject {
-                { "controller", "realtime" },
-                { "action", "count" },
-                { "body", new JObject {{ "roomId", roomId }}}
-            });
-            Assert.Equal<Int32>(count, res);
-        }
+      _api.Verify(new JObject {
+        { "controller", "realtime" },
+        { "action", "count" },
+        { "body", new JObject {{ "roomId", roomId }}}
+      });
+      Assert.Equal<Int32>(count, res);
+    }
 
-        [Fact]
-        public async void PublishAsyncTest()
-        {
-            string index = "an_index";
-            string collection = "to";
-            JObject message = new JObject { { "infinity", "and beyond" } };
+    [Fact]
+    public async void PublishAsyncTest() {
+      _api.SetResult(new JObject { { "result", "whatever" } });
 
-            await _realtimeController.PublishAsync(index, collection, message);
+      string index = "an_index";
+      string collection = "to";
+      JObject message = new JObject { { "infinity", "and beyond" } };
 
-            _api.Verify(new JObject{
-                {"index" , index },
-                {"collection" , collection },
-                {"controller" , "realtime" },
-                {"action" ,"publish" },
-                {"body" , message },
-            });
-        }
+      await _realtimeController.PublishAsync(index, collection, message);
 
-        [Theory]
-        [
-            MemberData(nameof(SubscribeOptionsData))
-        ]
-        public async void SubscribeAsyncTest(SubscribeOptions options)
-        {
-            string roomId = "A113";
-            string channel = "a_channel";
-            _api.SetResult(new JObject { {
+      _api.Verify(new JObject{
+        {"index" , index },
+        {"collection" , collection },
+        {"controller" , "realtime" },
+        {"action" ,"publish" },
+        {"body" , message },
+      });
+    }
+
+    [Theory]
+    [MemberData(nameof(SubscribeOptionsData))]
+    public async void SubscribeAsyncTest(SubscribeOptions options) {
+      string roomId = "A113";
+      string channel = "a_channel";
+      _api.SetResult(new JObject { {
                 "result", new JObject {
                     { "roomId", roomId },
                     { "channel", channel } }
                 } }
-            );
-            string index = "an_index";
-            string collection = "a_collection";
-            JObject filters = new JObject { { "studio", "pixar" } };
-            JObject expectedQuery = new JObject {
+      );
+      string index = "an_index";
+      string collection = "a_collection";
+      JObject filters = new JObject { { "studio", "pixar" } };
+      JObject expectedQuery = new JObject {
                 {"index", index},
                 {"collection",collection},
                 {"controller", "realtime"},
                 {"action", "subscribe"},
                 {"body", filters}
             };
-            if (options != null)
-            {
-                expectedQuery.Merge(JObject.FromObject(options));
-            }
-            Mock<RealtimeController.NotificationHandler> notificationHandlerMock = new Mock<RealtimeController.NotificationHandler>();
+      if (options != null) {
+        expectedQuery.Merge(JObject.FromObject(options));
+      }
+      Mock<RealtimeController.NotificationHandler> notificationHandlerMock = new Mock<RealtimeController.NotificationHandler>();
 
-            string res = await _realtimeController.SubscribeAsync(index, collection, filters, notificationHandlerMock.Object, options);
+      string res = await _realtimeController.SubscribeAsync(index, collection, filters, notificationHandlerMock.Object, options);
 
-            _api.Verify(expectedQuery);
-            Assert.Equal(roomId, res);
-        }
+      _api.Verify(expectedQuery);
+      Assert.Equal(roomId, res);
+    }
 
-        [Fact]
-        public async void UnsubscribeAsyncTest()
-        {
-            //First we need to subscribe to "a_collection"
-            string index = "an_index";
-            string collection = "a_collection";
-            JObject filters = new JObject { { "studio", "pixar" } };
-            string roomId = "A113";
-            string channel = "a_channel";
-            _api.SetResult(new JObject { {
+    [Fact]
+    public async void UnsubscribeAsyncTest() {
+      //First we need to subscribe to "a_collection"
+      string index = "an_index";
+      string collection = "a_collection";
+      JObject filters = new JObject { { "studio", "pixar" } };
+      string roomId = "A113";
+      string channel = "a_channel";
+      _api.SetResult(new JObject { {
                 "result", new JObject {
                     { "roomId", roomId },
                     { "channel", channel } }
                 } }
-            );
-            Mock<RealtimeController.NotificationHandler> notificationHandlerMock = new Mock<RealtimeController.NotificationHandler>();
+      );
+      Mock<RealtimeController.NotificationHandler> notificationHandlerMock = new Mock<RealtimeController.NotificationHandler>();
 
-            await _realtimeController.SubscribeAsync(index, collection, filters, notificationHandlerMock.Object);
+      await _realtimeController.SubscribeAsync(index, collection, filters, notificationHandlerMock.Object);
 
-            //Then we test that Notification Handler is not called after the unsubscription. 
-            _api.SetResult(new JObject {{
+      //Then we test that Notification Handler is not called after the unsubscription. 
+      _api.SetResult(new JObject {{
                 "result",  new JObject {{ "roomId", roomId }}
                 }}
-            );
+      );
 
-            await _realtimeController.UnsubscribeAsync(roomId);
-            _api.Verify(new JObject {
+      await _realtimeController.UnsubscribeAsync(roomId);
+      _api.Verify(new JObject {
                 {"controller", "realtime"},
                 {"action", "unsubscribe"},
                 {"body", new JObject {{ "roomId", roomId}}}
             });
 
-            Response notif = Response.FromString("{room: 'a_channel'}");
-            _api.Mock.Raise(m => m.UnhandledResponse += null, this, notif);
-            notificationHandlerMock.Verify(m => m.Invoke(notif), Times.Never);
-        }
+      Response notif = Response.FromString("{room: 'a_channel'}");
+      _api.Mock.Raise(m => m.UnhandledResponse += null, this, notif);
+      notificationHandlerMock.Verify(m => m.Invoke(notif), Times.Never);
+    }
 
-        [Fact]
-        public void NotificationHandlerTokenExpiredTest()
-        {
-            _api.Mock.Raise(m => m.UnhandledResponse += null, this, Response.FromString(@"{type: 'TokenExpired'}"));
+    [Fact]
+    public void NotificationHandlerTokenExpiredTest() {
+      _api.Mock.Raise(m => m.UnhandledResponse += null, this, Response.FromString(@"{type: 'TokenExpired'}"));
 
-            _api.Mock.Verify(m => m.DispatchTokenExpired(), Times.Once());
-        }
+      _api.Mock.Verify(m => m.DispatchTokenExpired(), Times.Once());
+    }
 
-        [Fact]
-        public async void NotificationHandlerTest()
-        {
-            //First we subscribe to a collection
-            string index = "an_index";
-            string collection = "a_collection";
-            JObject filters = new JObject { { "studio", "pixar" } };
-            _api.SetResult(new JObject { {
+    [Fact]
+    public async void NotificationHandlerTest() {
+      //First we subscribe to a collection
+      string index = "an_index";
+      string collection = "a_collection";
+      JObject filters = new JObject { { "studio", "pixar" } };
+      _api.SetResult(new JObject { {
                 "result", new JObject {
                     { "roomId", "A113"},
                     { "channel", "a_channel"} }
                 } }
-            );
-            Mock<RealtimeController.NotificationHandler> notificationHandlerMock = new Mock<RealtimeController.NotificationHandler>();
-            await _realtimeController.SubscribeAsync(index, collection, filters, notificationHandlerMock.Object);
+      );
+      Mock<RealtimeController.NotificationHandler> notificationHandlerMock = new Mock<RealtimeController.NotificationHandler>();
+      await _realtimeController.SubscribeAsync(index, collection, filters, notificationHandlerMock.Object);
 
-            //Then we trigger a notification
-            Response notif = Response.FromString("{room: 'a_channel'}");
-            _api.Mock.Raise(m => m.UnhandledResponse += null, this, notif);
+      //Then we trigger a notification
+      Response notif = Response.FromString("{room: 'a_channel'}");
+      _api.Mock.Raise(m => m.UnhandledResponse += null, this, notif);
 
-            //Then we can check that the handler has been called
-            notificationHandlerMock.Verify(m => m.Invoke(notif), Times.AtLeastOnce);
-        }
+      //Then we can check that the handler has been called
+      notificationHandlerMock.Verify(m => m.Invoke(notif), Times.AtLeastOnce);
+    }
 
-        public static IEnumerable<object[]> SubscribeOptionsData()
-        {
-            yield return new object[] { null };
-            yield return new object[] { new SubscribeOptions() };
-            yield return new object[] {
+    public static IEnumerable<object[]> SubscribeOptionsData() {
+      yield return new object[] { null };
+      yield return new object[] { new SubscribeOptions() };
+      yield return new object[] {
                 JsonConvert.DeserializeObject<SubscribeOptions>(@"{
                     scope: 'all',
                     users: 'all',
@@ -178,6 +165,6 @@ namespace Kuzzle.Tests.API.Controllers
                     }
                 }")
             };
-        }
     }
+  }
 }

--- a/Kuzzle.Tests/API/KuzzleApiMock.cs
+++ b/Kuzzle.Tests/API/KuzzleApiMock.cs
@@ -30,7 +30,10 @@ namespace Kuzzle.Tests.API {
     public void SetResult(string apiResult) {
       Mock
         .Setup(api => api.QueryAsync(It.IsAny<JObject>()))
-        .Returns(Task.FromResult(Response.FromString(apiResult)));
+        .Returns(
+          Task
+            .FromResult(Response.FromString(apiResult))
+            .ConfigureAwait(false));
     }
 
     public void SetError(int status = 400, string message = "Errored Test") {
@@ -39,7 +42,7 @@ namespace Kuzzle.Tests.API {
 
       Mock
         .Setup(api => api.QueryAsync(It.IsAny<JObject>()))
-        .Returns(t.Task);
+        .Returns(t.Task.ConfigureAwait(false));
     }
 
     public void Verify(JObject expectedQuery) {

--- a/Kuzzle/API/Controllers/RealtimeController.cs
+++ b/Kuzzle/API/Controllers/RealtimeController.cs
@@ -122,7 +122,10 @@ namespace KuzzleSdk.API.Controllers {
     /// the message content.
     /// </summary>
     public async Task PublishAsync(
-        string index, string collection, JObject message) {
+      string index,
+      string collection,
+      JObject message
+    ) {
       await api.QueryAsync(new JObject {
         { "controller", "realtime" },
         { "action", "publish" },

--- a/Kuzzle/Kuzzle.cs
+++ b/Kuzzle/Kuzzle.cs
@@ -42,7 +42,7 @@ namespace KuzzleSdk {
     /// </summary>
     /// <returns>The query response.</returns>
     /// <param name="query">Kuzzle API query</param>
-    Task<Response> QueryAsync(JObject query);
+    ConfiguredTaskAwaitable<Response> QueryAsync(JObject query);
 
     /// <summary>
     /// Dispatches a TokenExpired event.
@@ -109,7 +109,7 @@ namespace KuzzleSdk {
     /// Exposes actions from the "document" Kuzzle API controller
     /// </summary>
     public DocumentController Document { get; private set; }
-  
+
     /// <summary>
     /// Exposes actions from the "index" Kuzzle API controller
     /// </summary>
@@ -129,6 +129,8 @@ namespace KuzzleSdk {
     /// Exposes actions from the "bulk" Kuzzle API controller
     /// </summary>
     public BulkController Bulk { get; private set; }
+
+    /// <summary>
     /// Exposes actions from the "admin" Kuzzle API controller
     /// </summary>
     public AdminController Admin { get; private set; }
@@ -266,7 +268,7 @@ namespace KuzzleSdk {
     /// </summary>
     /// <returns>API response</returns>
     /// <param name="query">Kuzzle API query</param>
-    public Task<Response> QueryAsync(JObject query) {
+    public ConfiguredTaskAwaitable<Response> QueryAsync(JObject query) {
       if (query == null) {
         throw new Exceptions.InternalException("You must provide a query", 400);
       }
@@ -304,7 +306,7 @@ namespace KuzzleSdk {
         requests[requestId] = new TaskCompletionSource<Response>();
       }
 
-      return requests[requestId].Task;
+      return requests[requestId].Task.ConfigureAwait(false);
     }
   }
 }


### PR DESCRIPTION
# Description

Configures a default awaiter for `Task` instances returned by the SDK to prevent potential [deadlocks on UI applications](https://medium.com/bynder-tech/c-why-you-should-use-configureawait-false-in-your-library-code-d7837dce3d7f).

# Boyscout

* Let monodevelop reapply the code styling as defined in the solution file. 
* Fix a missing "SetApiResult" in the Realtime.PublishAsync unit test leading to a failure
