### PR TITLE
Change DocumentController.MDeleteAsync args and returned value

### DIFF
--- a/Kuzzle.Tests/API/Controllers/DocumentControllerTest.cs
+++ b/Kuzzle.Tests/API/Controllers/DocumentControllerTest.cs
@@ -256,9 +256,9 @@ namespace Kuzzle.Tests.API.Controllers {
     public async void MDeleteAsync(bool refresh) {
       _api.SetResult("{ result: ['foo', 'bar', 'baz'] }");
 
-      var ids = new JArray { "foo", "bar", "baz" };
+      var ids = new string[] { "foo", "bar", "baz" };
 
-      JArray result = await _documentController.MDeleteAsync(
+      string[] result = await _documentController.MDeleteAsync(
         "foo",
         "bar",
         ids,
@@ -273,14 +273,11 @@ namespace Kuzzle.Tests.API.Controllers {
       };
 
       expected.Add("body", new JObject());
-      ((JObject)expected["body"]).Add("ids", ids);
+      ((JObject)expected["body"]).Add("ids", new JArray(ids));
 
       _api.Verify(expected);
 
-      Assert.Equal(
-        new JArray { "foo", "bar", "baz" },
-        result,
-        new JTokenEqualityComparer());
+      Assert.Equal(ids, result);
     }
 
     [Fact]

--- a/Kuzzle/API/Controllers/DocumentController.cs
+++ b/Kuzzle/API/Controllers/DocumentController.cs
@@ -205,16 +205,16 @@ namespace KuzzleSdk.API.Controllers {
     /// Throws a partial error(error code 206) if one or more document
     /// deletions fail.
     /// </summary>
-    public async Task<JArray> MDeleteAsync(
+    public async Task<string[]> MDeleteAsync(
       string index,
       string collection,
-      JArray ids,
+      string[] ids,
       bool waitForRefresh = false
     ) {
       var request = new JObject {
         { "controller", "document" },
         { "action", "mDelete" },
-        { "body", new JObject{ { "ids", ids } } },
+        { "body", new JObject{ { "ids", new JArray(ids) } } },
         { "index", index },
         { "collection", collection },
         {"waitForRefresh", waitForRefresh},
@@ -222,7 +222,7 @@ namespace KuzzleSdk.API.Controllers {
 
       Response response = await api.QueryAsync(request);
 
-      return (JArray)response.Result;
+      return response.Result.ToObject<string[]>();
     }
 
     /// <summary>

--- a/doc/1/controllers/document/m-delete/index.md
+++ b/doc/1/controllers/document/m-delete/index.md
@@ -14,10 +14,10 @@ Throws a partial error (error code 206) if one or more document deletions fail.
 ## Arguments
 
 ```csharp
-public async Task<JArray> MDeleteAsync(
+public async Task<string[]> MDeleteAsync(
   string index, 
   string collection, 
-  JArray ids, 
+  string[] ids, 
   bool waitForRefresh = false);
 
 ```
@@ -28,12 +28,12 @@ public async Task<JArray> MDeleteAsync(
 | ------------ | ----------------------------------------- | ------------------------------ |
 | `index`      | <pre>string</pre>             | Index name                     |
 | `collection` | <pre>string</pre>             | Collection name                |
-| `ids`        | <pre>JArray</pre> | IDs of the documents to delete |
+| `ids`        | <pre>string[]</pre> | IDs of the documents to delete |
 | `waitForRefresh`   | <pre>bool</pre><br/>(`false`)       | If `true`, waits for the change to be reflected for `search` (up to 1s)           |
 
 ## Return
 
-A JArray containing the deleted documents IDs.
+An array of strings containing the deleted document IDs.
 
 ## Exceptions
 

--- a/doc/1/controllers/document/m-delete/snippets/m-delete.cs
+++ b/doc/1/controllers/document/m-delete/snippets/m-delete.cs
@@ -5,7 +5,7 @@ try {
     "yellow-taxi",
     new string[] { "some-id", "some-other-id" });
 
-  Console.WriteLine($"Successfully deleted {deleted.Count} documents");
+  Console.WriteLine($"Successfully deleted {deleted.Length} documents");
 } catch (KuzzleException e) {
   Console.Error.WriteLine(e);
 }

--- a/doc/1/controllers/document/m-delete/snippets/m-delete.cs
+++ b/doc/1/controllers/document/m-delete/snippets/m-delete.cs
@@ -1,9 +1,9 @@
 
 try {
-  JArray deleted = await kuzzle.Document.MDeleteAsync(
+  string[] deleted = await kuzzle.Document.MDeleteAsync(
     "nyc-open-data",
     "yellow-taxi",
-    JArray.Parse(@"[""some-id"", ""some-other-id""]"));
+    new string[] { "some-id", "some-other-id" });
 
   Console.WriteLine($"Successfully deleted {deleted.Count} documents");
 } catch (KuzzleException e) {


### PR DESCRIPTION
# Description

Following [this review](https://github.com/kuzzleio/kuzzle/pull/1396), this PR changes the arguments and the returned value of the `DocumentController.MDeleteAsync` method to use a native C# type instead of a JSON array.