### PR TITLE
Documentation: fix language tag in code examples

### DIFF
--- a/doc/1/controllers/index/create/index.md
+++ b/doc/1/controllers/index/create/index.md
@@ -11,7 +11,7 @@ Creates a new index in Kuzzle
 
 ## Arguments
 
-```cs
+```csharp
 Task CreateAsync(string index);
 ```
 

--- a/doc/1/controllers/index/delete/index.md
+++ b/doc/1/controllers/index/delete/index.md
@@ -11,7 +11,7 @@ Deletes an entire index from Kuzzle.
 
 ## Arguments
 
-```cs
+```csharp
 Task DeleteAsync(string index);
 ```
 

--- a/doc/1/controllers/index/exists/index.md
+++ b/doc/1/controllers/index/exists/index.md
@@ -11,7 +11,7 @@ Checks if the given index exists in Kuzzle.
 
 ## Arguments
 
-```cs
+```csharp
 Task<bool> ExistsAsync(string index);
 ```
 

--- a/doc/1/controllers/index/get-auto-refresh/index.md
+++ b/doc/1/controllers/index/get-auto-refresh/index.md
@@ -21,7 +21,7 @@ we recommend that you avoid using it in production or at least carefully monitor
 
 ## Arguments
 
-```cs
+```csharp
 Task<bool> GetAutoRefreshAsync(string index);
 ```
 

--- a/doc/1/controllers/index/list/index.md
+++ b/doc/1/controllers/index/list/index.md
@@ -11,7 +11,7 @@ Gets the complete list of indexes handled by Kuzzle.
 
 ## Arguments
 
-```cs
+```csharp
 Task<JArray> ListAsync();
 ```
 

--- a/doc/1/controllers/index/m-delete/index.md
+++ b/doc/1/controllers/index/m-delete/index.md
@@ -11,7 +11,7 @@ Deletes multiple indexes.
 
 ## Arguments
 
-```cs
+```csharp
 Task<JArray> MDeleteAsync(JArray indexes);
 ```
 

--- a/doc/1/controllers/index/refresh-internal/index.md
+++ b/doc/1/controllers/index/refresh-internal/index.md
@@ -21,7 +21,7 @@ From the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticse
 
 ## Arguments
 
-```cs
+```csharp
 Task RefreshInternalAsync();
 ```
 

--- a/doc/1/controllers/index/refresh/index.md
+++ b/doc/1/controllers/index/refresh/index.md
@@ -21,7 +21,7 @@ From the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticse
 
 ## Arguments
 
-```cs
+```csharp
 Task RefreshAsync(string index);
 ```
 

--- a/doc/1/controllers/index/set-auto-refresh/index.md
+++ b/doc/1/controllers/index/set-auto-refresh/index.md
@@ -21,7 +21,7 @@ we recommend that you avoid using it in production or at least carefully monitor
 
 ## Arguments
 
-```cs
+```csharp
 Task SetAutoRefreshAsync(string index , boolean autoRefresh);
 ```
 


### PR DESCRIPTION
# Description

Use the correct language tag in code examples.

# How to test

Compile the documentation: loads of warnings without this fix.

Also, current documentation on production (Index/CreateAsync):

![Screenshot from 2019-11-26 10-57-28](https://user-images.githubusercontent.com/12997967/69619270-a4125080-103b-11ea-8b7e-f1b8e883a17e.png)


Fixed documentation:

![Screenshot from 2019-11-26 10-57-21](https://user-images.githubusercontent.com/12997967/69619290-aa083180-103b-11ea-9107-98fcad75b667.png)
