### PR TITLE
Make WebSocket.ResetState reentrant

### DIFF
--- a/Kuzzle/Protocol/WebSocket.cs
+++ b/Kuzzle/Protocol/WebSocket.cs
@@ -282,12 +282,7 @@ namespace KuzzleSdk.Protocol {
           ConnectAsync(reconnectCancellationToken.Token).Wait();
           return;
         } catch (Exception) {
-          socket.Abort();
-          socket = null;
-          receiveCancellationToken?.Cancel();
-          receiveCancellationToken = null;
-          sendCancellationToken?.Cancel();
-          sendCancellationToken = null;
+          ResetState();
           Thread.Sleep(ReconnectionDelay);
         }
       }
@@ -295,7 +290,7 @@ namespace KuzzleSdk.Protocol {
     }
 
     private void ResetState() {
-      socket.Abort();
+      socket?.Abort();
       socket = null;
       receiveCancellationToken?.Cancel();
       receiveCancellationToken = null;


### PR DESCRIPTION
# Description

When the WebSocket protocol tries to reconnect and, ultimately, fails, it resets the socket, sets it to null, and then changes its own state to `Closed`. This state change triggers a reset which, in turn, force-closes the current socket and sets it to null.
Since the socket has already been closed and set to null, this ends up in a NullReferenceException.

This PR makes the `WebSocket.ResetState` function reentrant.

# Boyscout

Use `WebSocket.ResetState` at the end of each reconnection attempt to prevent code duplication.