### PR TITLE
Make WebSocket.ResetState reentrant

### DIFF
--- a/Kuzzle.Tests/API/Controllers/AuthControllerTest.cs
+++ b/Kuzzle.Tests/API/Controllers/AuthControllerTest.cs
@@ -250,11 +250,16 @@ namespace Kuzzle.Tests.API.Controllers {
 
       JObject result = await _authController.RefreshTokenAsync(expiresIn);
 
-      _api.Verify(new JObject {
+      var expectedQuery = new JObject {
         { "controller", "auth" },
-        { "action", "refreshToken" },
-        { "expiresIn", expiresIn?.TotalMilliseconds }
-      });
+        { "action", "refreshToken" }
+      };
+
+      if (expiresIn != null) {
+        expectedQuery["expiresIn"] = expiresIn?.TotalMilliseconds;
+      }
+
+      _api.Verify(expectedQuery);
 
       Assert.Equal<JObject>(
         expected,

--- a/Kuzzle/API/Controllers/AuthController.cs
+++ b/Kuzzle/API/Controllers/AuthController.cs
@@ -144,13 +144,19 @@ namespace KuzzleSdk.API.Controllers {
       JObject credentials,
       TimeSpan? expiresIn = null
     ) {
-      Response response = await api.QueryAsync(new JObject {
+      var query = new JObject {
         { "controller", "auth" },
         { "action", "login" },
         { "strategy", strategy },
         { "body", credentials },
         { "expiresIn", expiresIn?.TotalMilliseconds }
-      });
+      };
+
+      if (expiresIn != null) {
+        query["expiresIn"] = expiresIn?.TotalMilliseconds;
+      }
+
+      Response response = await api.QueryAsync(query);
 
       api.AuthenticationToken = (string)response.Result["jwt"];
 
@@ -176,11 +182,16 @@ namespace KuzzleSdk.API.Controllers {
     /// Refreshes an authentication token.
     /// </summary>
     public async Task<JObject> RefreshTokenAsync(TimeSpan? expiresIn = null) {
-      Response response = await api.QueryAsync(new JObject {
+      var query = new JObject {
         { "controller", "auth" },
-        { "action", "refreshToken" },
-        { "expiresIn", expiresIn?.TotalMilliseconds }
-      });
+        { "action", "refreshToken" }
+      };
+
+      if (expiresIn != null) {
+        query["expiresIn"] = expiresIn?.TotalMilliseconds;
+      }
+
+      var response = await api.QueryAsync(query);
 
       api.AuthenticationToken = (string)response.Result["jwt"];
 

--- a/Kuzzle/Protocol/WebSocket.cs
+++ b/Kuzzle/Protocol/WebSocket.cs
@@ -282,12 +282,7 @@ namespace KuzzleSdk.Protocol {
           ConnectAsync(reconnectCancellationToken.Token).Wait();
           return;
         } catch (Exception) {
-          socket.Abort();
-          socket = null;
-          receiveCancellationToken?.Cancel();
-          receiveCancellationToken = null;
-          sendCancellationToken?.Cancel();
-          sendCancellationToken = null;
+          ResetState();
           Thread.Sleep(ReconnectionDelay);
         }
       }
@@ -295,7 +290,7 @@ namespace KuzzleSdk.Protocol {
     }
 
     private void ResetState() {
-      socket.Abort();
+      socket?.Abort();
       socket = null;
       receiveCancellationToken?.Cancel();
       receiveCancellationToken = null;

--- a/doc/2/getting-started/standalone/index.md
+++ b/doc/2/getting-started/standalone/index.md
@@ -17,7 +17,7 @@ To follow this tutorial, you must have a Kuzzle Server up and running. Follow th
 
 
 ::: info
-Having trouble? Get in touch with us on [Discord](https://join.discord.kuzzle.io)!
+Having trouble? Get in touch with us on [Discord](http://join.discord.kuzzle.io)!
 :::
 
 ## Explore the SDK

--- a/doc/2/getting-started/standalone/index.md
+++ b/doc/2/getting-started/standalone/index.md
@@ -17,7 +17,7 @@ To follow this tutorial, you must have a Kuzzle Server up and running. Follow th
 
 
 ::: info
-Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)!
+Having trouble? Get in touch with us on [Discord](https://join.discord.kuzzle.io)!
 :::
 
 ## Explore the SDK


### PR DESCRIPTION
# Description

(note: this is the v2 version of this already validated PR: #54 )

When the WebSocket protocol tries to reconnect and, ultimately, fails, it resets the socket, sets it to null, and then changes its own state to `Closed`. This state change triggers a reset which, in turn, force-closes the current socket and sets it to null.
Since the socket has already been closed and set to null, this ends up in a NullReferenceException.

This PR makes the `WebSocket.ResetState` function reentrant.

# Boyscout

Use `WebSocket.ResetState` at the end of each reconnection attempt to prevent code duplication.