### PR TITLE
Fix expiresIn option handling

### DIFF
--- a/Kuzzle.Tests/API/Controllers/AuthControllerTest.cs
+++ b/Kuzzle.Tests/API/Controllers/AuthControllerTest.cs
@@ -192,13 +192,18 @@ namespace Kuzzle.Tests.API.Controllers {
         credentials,
         expiresIn);
 
-      _api.Verify(new JObject {
+      var expectedQuery = new JObject {
         { "controller", "auth" },
         { "action", "login" },
         { "strategy", "foostrategy" },
-        { "expiresIn", expiresIn?.TotalMilliseconds },
-        { "body", credentials }
-      });
+        { "body", credentials },
+      };
+
+      if (expiresIn != null) {
+        expectedQuery["expiresIn"] = $"{Math.Floor((double)expiresIn?.TotalSeconds)}s";
+      }
+
+      _api.Verify(expectedQuery);
 
       Assert.Equal<JObject>(
         expected,
@@ -250,11 +255,16 @@ namespace Kuzzle.Tests.API.Controllers {
 
       JObject result = await _authController.RefreshTokenAsync(expiresIn);
 
-      _api.Verify(new JObject {
+      var expectedQuery = new JObject {
         { "controller", "auth" },
         { "action", "refreshToken" },
-        { "expiresIn", expiresIn?.TotalMilliseconds }
-      });
+      };
+
+      if (expiresIn != null) {
+        expectedQuery["expiresIn"] = $"{Math.Floor((double)expiresIn?.TotalSeconds)}s";
+      }
+
+      _api.Verify(expectedQuery);
 
       Assert.Equal<JObject>(
         expected,

--- a/Kuzzle/API/Controllers/AuthController.cs
+++ b/Kuzzle/API/Controllers/AuthController.cs
@@ -144,13 +144,19 @@ namespace KuzzleSdk.API.Controllers {
       JObject credentials,
       TimeSpan? expiresIn = null
     ) {
-      Response response = await api.QueryAsync(new JObject {
+      var query = new JObject {
         { "controller", "auth" },
         { "action", "login" },
         { "strategy", strategy },
         { "body", credentials },
-        { "expiresIn", expiresIn?.TotalMilliseconds }
-      });
+      };
+
+      if (expiresIn != null) {
+        // workaround to https://github.com/kuzzleio/kuzzle/issues/1784
+        query["expiresIn"] = $"{Math.Floor((double)expiresIn?.TotalSeconds)}s";
+      }
+
+      Response response = await api.QueryAsync(query);
 
       api.AuthenticationToken = (string)response.Result["jwt"];
 
@@ -176,11 +182,17 @@ namespace KuzzleSdk.API.Controllers {
     /// Refreshes an authentication token.
     /// </summary>
     public async Task<JObject> RefreshTokenAsync(TimeSpan? expiresIn = null) {
-      Response response = await api.QueryAsync(new JObject {
+      var query = new JObject {
         { "controller", "auth" },
         { "action", "refreshToken" },
-        { "expiresIn", expiresIn?.TotalMilliseconds }
-      });
+      };
+
+      if (expiresIn != null) {
+        // workaround to https://github.com/kuzzleio/kuzzle/issues/1784
+        query["expiresIn"] = $"{Math.Floor((double)expiresIn?.TotalSeconds)}s";
+      }
+
+      Response response = await api.QueryAsync(query);
 
       api.AuthenticationToken = (string)response.Result["jwt"];
 


### PR DESCRIPTION
# Description

Workaround to kuzzleio/kuzzle#1784: submit the expiration delay as a rounded number of seconds, to make Kuzzle correctly convert it to sign a new token.
