### PR TITLE
Fix expiresIn option handling

### DIFF
--- a/Kuzzle.Tests/API/Controllers/AuthControllerTest.cs
+++ b/Kuzzle.Tests/API/Controllers/AuthControllerTest.cs
@@ -192,13 +192,18 @@ namespace Kuzzle.Tests.API.Controllers {
         credentials,
         expiresIn);
 
-      _api.Verify(new JObject {
+      var expectedQuery = new JObject {
         { "controller", "auth" },
         { "action", "login" },
         { "strategy", "foostrategy" },
-        { "expiresIn", expiresIn?.TotalMilliseconds },
-        { "body", credentials }
-      });
+        { "body", credentials },
+      };
+
+      if (expiresIn != null) {
+        expectedQuery["expiresIn"] = $"{Math.Floor((double)expiresIn?.TotalSeconds)}s";
+      }
+
+      _api.Verify(expectedQuery);
 
       Assert.Equal<JObject>(
         expected,
@@ -252,11 +257,11 @@ namespace Kuzzle.Tests.API.Controllers {
 
       var expectedQuery = new JObject {
         { "controller", "auth" },
-        { "action", "refreshToken" }
+        { "action", "refreshToken" },
       };
 
       if (expiresIn != null) {
-        expectedQuery["expiresIn"] = expiresIn?.TotalMilliseconds;
+        expectedQuery["expiresIn"] = $"{Math.Floor((double)expiresIn?.TotalSeconds)}s";
       }
 
       _api.Verify(expectedQuery);

--- a/Kuzzle/API/Controllers/AuthController.cs
+++ b/Kuzzle/API/Controllers/AuthController.cs
@@ -149,11 +149,10 @@ namespace KuzzleSdk.API.Controllers {
         { "action", "login" },
         { "strategy", strategy },
         { "body", credentials },
-        { "expiresIn", expiresIn?.TotalMilliseconds }
       };
 
       if (expiresIn != null) {
-        query["expiresIn"] = expiresIn?.TotalMilliseconds;
+        query["expiresIn"] = $"{Math.Floor((double)expiresIn?.TotalSeconds)}s";
       }
 
       Response response = await api.QueryAsync(query);
@@ -188,7 +187,7 @@ namespace KuzzleSdk.API.Controllers {
       };
 
       if (expiresIn != null) {
-        query["expiresIn"] = expiresIn?.TotalMilliseconds;
+        query["expiresIn"] = $"{Math.Floor((double)expiresIn?.TotalSeconds)}s";
       }
 
       var response = await api.QueryAsync(query);


### PR DESCRIPTION
# Description

Workaround to kuzzleio/kuzzle#1784: submit the expiration delay as a rounded number of seconds, to make Kuzzle correctly convert it to sign a new token.
