### PR TITLE
Fix network recovering

### DIFF
--- a/Kuzzle.Tests/Offline/Query/QueryReplayerTest.cs
+++ b/Kuzzle.Tests/Offline/Query/QueryReplayerTest.cs
@@ -147,12 +147,12 @@ namespace Kuzzle.Tests.Offline.Query {
       testableOfflineManager.MaxQueueSize = -1;
       queryReplayer.Lock = false;
 
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foo', action: 'bar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'bar', action: 'foor'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foobar', action: 'foobar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'barfoo', action: 'foobar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foobar', action: 'barfoo'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'barfoo', action: 'barfoo'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '1', controller: 'foo', action: 'bar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '2', controller: 'bar', action: 'foor'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '3', controller: 'foobar', action: 'foobar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '4', controller: 'barfoo', action: 'foobar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '5', controller: 'foobar', action: 'barfoo'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '6', controller: 'barfoo', action: 'barfoo'}")));
 
       Assert.Equal(6, queryReplayer.Count);
 
@@ -168,12 +168,12 @@ namespace Kuzzle.Tests.Offline.Query {
       testableOfflineManager.MaxQueueSize = -1;
       queryReplayer.Lock = false;
 
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foo', action: 'bar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'bar', action: 'foor'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foobar', action: 'foobar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'barfoo', action: 'foobar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foobar', action: 'barfoo'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'barfoo', action: 'barfoo'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '1', controller: 'foo', action: 'bar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '2', controller: 'bar', action: 'foor'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '3', controller: 'foobar', action: 'foobar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '4', controller: 'barfoo', action: 'foobar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '5', controller: 'foobar', action: 'barfoo'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '6', controller: 'barfoo', action: 'barfoo'}")));
 
       Assert.Equal(6, queryReplayer.Count);
 

--- a/Kuzzle/Kuzzle.csproj
+++ b/Kuzzle/Kuzzle.csproj
@@ -11,7 +11,6 @@
     <Description>Official C# SDK for Kuzzle</Description>
     <RootNamespace>KuzzleSdk</RootNamespace>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <ReleaseVersion>1.0.0</ReleaseVersion>
     <PackageVersion>1.0.0</PackageVersion>
     <PackOnBuild>false</PackOnBuild>
   </PropertyGroup>
@@ -46,6 +45,10 @@
     <MonoDevelop>
       <Properties>
         <Deployment.LinuxDeployData generatePcFile="False" />
+        <Policies>
+          <TextStylePolicy RemoveTrailingWhitespace="True" NoTabsAfterNonTabs="False" EolMarker="Native" FileWidth="80" TabWidth="2" TabsToSpaces="True" IndentWidth="2" scope="text/x-csharp" />
+          <CSharpFormattingPolicy IndentBlock="True" IndentBraces="False" IndentSwitchSection="True" IndentSwitchCaseSection="True" LabelPositioning="OneLess" NewLineForElse="True" NewLineForCatch="True" NewLineForFinally="True" NewLineForMembersInObjectInit="True" NewLineForMembersInAnonymousTypes="True" NewLineForClausesInQuery="True" SpaceWithinMethodDeclarationParenthesis="False" SpaceBetweenEmptyMethodDeclarationParentheses="False" SpaceAfterMethodCallName="False" SpaceWithinMethodCallParentheses="False" SpaceBetweenEmptyMethodCallParentheses="False" SpaceAfterControlFlowStatementKeyword="True" SpaceWithinExpressionParentheses="False" SpaceWithinCastParentheses="False" SpaceWithinOtherParentheses="False" SpaceAfterCast="False" SpacesIgnoreAroundVariableDeclaration="False" SpaceBeforeOpenSquareBracket="False" SpaceBetweenEmptySquareBrackets="False" SpaceWithinSquareBrackets="False" SpaceAfterColonInBaseTypeDeclaration="True" SpaceAfterComma="True" SpaceAfterDot="False" SpaceAfterSemicolonsInForStatement="True" SpaceBeforeColonInBaseTypeDeclaration="True" SpaceBeforeComma="False" SpaceBeforeDot="False" SpaceBeforeSemicolonsInForStatement="False" SpacingAroundBinaryOperator="Single" WrappingPreserveSingleLine="True" WrappingKeepStatementsOnSingleLine="True" PlaceSystemDirectiveFirst="True" NewLinesForBracesInTypes="False" NewLinesForBracesInMethods="False" NewLinesForBracesInProperties="False" NewLinesForBracesInAccessors="False" NewLinesForBracesInAnonymousMethods="False" NewLinesForBracesInControlBlocks="False" NewLinesForBracesInAnonymousTypes="False" NewLinesForBracesInObjectCollectionArrayInitializers="False" NewLinesForBracesInLambdaExpressionBody="False" SpacingAfterMethodDeclarationName="True" scope="text/x-csharp" />
+        </Policies>
       </Properties>
     </MonoDevelop>
   </ProjectExtensions>

--- a/Kuzzle/Offline/OfflineManager.cs
+++ b/Kuzzle/Offline/OfflineManager.cs
@@ -226,7 +226,6 @@ namespace KuzzleSdk.API.Offline {
 
     internal void StateChangeListener(object sender, ProtocolState state) {
       if (state == ProtocolState.Open && previousState == ProtocolState.Reconnecting) {
-
         kuzzle.GetEventHandler().DispatchReconnected();
 
         Task.Run(async () => {
@@ -235,6 +234,7 @@ namespace KuzzleSdk.API.Offline {
         });
 
       }
+
       previousState = state;
     }
 

--- a/Kuzzle/Offline/Query/QueryReplayer.cs
+++ b/Kuzzle/Offline/Query/QueryReplayer.cs
@@ -112,18 +112,20 @@ namespace KuzzleSdk {
             stopWatch.Reset();
             stopWatch.Start();
             queue.Add(new TimedQuery(query, 0));
-          } else {
+          }
+          else {
             TimedQuery previous = queue[queue.Count - 1];
             Int64 elapsedTime = stopWatch.ElapsedMilliseconds - previous.Time;
             elapsedTime = Math.Min(elapsedTime, offlineManager.MaxRequestDelay);
             queue.Add(new TimedQuery(query, previous.Time + elapsedTime));
           }
-          if (query["controller"]?.ToString() == "auth"
-              && (query["action"]?.ToString() == "login"
-                || query["action"]?.ToString() == "logout")
-              ) {
-                Lock = true;
-              }
+
+          String controller = query["controller"]?.ToString();
+          String action = query["action"]?.ToString();
+
+          if (controller == "auth" && (action == "login" || action == "logout")) {
+            Lock = true;
+          }
 
           return true;
         }
@@ -291,7 +293,7 @@ namespace KuzzleSdk {
 
           foreach (TimedQuery timedQuery in queue) {
             if (predicate(timedQuery.Query)) {
-              ReplayOneQuery(timedQuery, cancellationTokenSource.Token);
+              ReplayQuery(timedQuery, cancellationTokenSource.Token);
             }
           }
 

--- a/Kuzzle/Offline/Query/QueryReplayer.cs
+++ b/Kuzzle/Offline/Query/QueryReplayer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using KuzzleSdk.API;
 using KuzzleSdk.API.Offline;
 using Newtonsoft.Json.Linq;
 
@@ -73,6 +74,7 @@ namespace KuzzleSdk {
     private CancellationTokenSource cancellationTokenSource;
     private bool currentlyReplaying = false;
     private Stopwatch stopWatch = new Stopwatch();
+    private SemaphoreSlim queueSemaphore = new SemaphoreSlim(1, 1);
 
     /// <summary>
     /// Tells if the QueryReplayer is locked (i.e. it doesn't accept new queries).
@@ -103,7 +105,8 @@ namespace KuzzleSdk {
     public bool Enqueue(JObject query) {
       if (Lock || WaitLoginToReplay) return false;
 
-      lock (queue) {
+      queueSemaphore.Wait();
+      try {
         if (queue.Count < offlineManager.MaxQueueSize || offlineManager.MaxQueueSize < 0) {
           if (queue.Count == 0) {
             stopWatch.Reset();
@@ -125,6 +128,10 @@ namespace KuzzleSdk {
           return true;
         }
       }
+      finally {
+        queueSemaphore.Release();
+      }
+
       return false;
     }
 
@@ -139,7 +146,8 @@ namespace KuzzleSdk {
     /// Remove and return the first query that has been added to the queue.
     /// </summary>
     public JObject Dequeue() {
-      lock (queue) {
+      queueSemaphore.Wait();
+      try {
         if (queue.Count == 0) {
           return null;
         }
@@ -148,6 +156,9 @@ namespace KuzzleSdk {
         queue.RemoveAt(0);
 
         return query;
+      }
+      finally {
+        queueSemaphore.Release();
       }
     }
 
@@ -163,18 +174,32 @@ namespace KuzzleSdk {
     /// it is set with an exception and removed from the replayable queue.
     /// </summary>
     public void RejectQueries(Predicate<JObject> predicate, Exception exception) {
-      lock (queue) {
+      queueSemaphore.Wait();
+      try {
         foreach (TimedQuery timedQuery in queue) {
           if (predicate(timedQuery.Query)) {
-            kuzzle.GetRequestById(timedQuery.Query["requestId"]?.ToString())?.SetException(exception);
+            String requestId = timedQuery.Query["requestId"]?.ToString();
+
+            if (requestId != null) {
+              TaskCompletionSource<Response> task = kuzzle.GetRequestById(requestId);
+
+              if (task != null) {
+                task.SetException(exception);
+              }
+            }
           }
         }
+
         queue.RemoveAll((obj) => predicate(obj.Query));
+
         if (queue.Count == 0) {
           Lock = false;
           currentlyReplaying = false;
           WaitLoginToReplay = false;
         }
+      }
+      finally {
+        queueSemaphore.Release();
       }
     }
 
@@ -183,7 +208,8 @@ namespace KuzzleSdk {
     /// </summary>
     /// <returns>How many items where removed.</returns>
     public int Remove(Predicate<JObject> predicate) {
-      lock (queue) {
+      queueSemaphore.Wait();
+      try {
         if (queue.Count > 0) {
           Predicate<TimedQuery> timedQueryPredicate = timedQuery => predicate(timedQuery.Query);
           int itemsRemoved = queue.RemoveAll(timedQueryPredicate);
@@ -196,6 +222,9 @@ namespace KuzzleSdk {
           return itemsRemoved;
         }
       }
+      finally {
+        queueSemaphore.Release();
+      }
       return 0;
     }
 
@@ -203,12 +232,12 @@ namespace KuzzleSdk {
     /// Clear the queue.
     /// </summary>
     public void Clear() {
-      lock (queue) {
-        queue.Clear();
-        Lock = false;
-        currentlyReplaying = false;
-        WaitLoginToReplay = false;
-      }
+      queueSemaphore.Wait();
+      queue.Clear();
+      Lock = false;
+      currentlyReplaying = false;
+      WaitLoginToReplay = false;
+      queueSemaphore.Release();
     }
 
     internal delegate Task ReplayQueryFunc(TimedQuery timedQuery, CancellationToken cancellationToken);
@@ -255,17 +284,21 @@ namespace KuzzleSdk {
 
       if (resetWaitLogin) WaitLoginToReplay = false;
 
-      lock (queue) {
+      queueSemaphore.Wait();
+      try {
         if (queue.Count > 0) {
           currentlyReplaying = true;
 
           foreach (TimedQuery timedQuery in queue) {
             if (predicate(timedQuery.Query)) {
-              ReplayQuery(timedQuery, cancellationTokenSource.Token);
+              ReplayOneQuery(timedQuery, cancellationTokenSource.Token);
             }
           }
 
         }
+      }
+      finally {
+        queueSemaphore.Release();
       }
       return cancellationTokenSource;
     }


### PR DESCRIPTION
# Description

Fix a number of problems when handling disconnections, and with asynchronous tasks in general.


## Network disconnection

When `AbstractProtocol.AutoRecover` is set to true:

* requests sent through the network would never be resolved when the connection is lost before they receive a response. This means that clients awaiting for a response would freeze forever. With this PR, those tasks are correctly rejected with a `ConnectionLost` exception (we cannot queue them: as far as the SDK is concerned, it cannot know if these requests were received and processed by Kuzzle or not)
* there was a race condition when triggering the threaded recovering process where, in rare cases, 2 reconnection attempts would run in parallel, doubling the number of opened sockets

## Asynchronous tasks

* Race conditions could occur and corrupt the requests cache, or freeze the SDK because of an unhandled exception, because of an incorrect use of `lock` (this keyword has no impact when multiple accesses are made to the same "locked" object within the same thread) => semaphores are now used to circumvent the problem
* Requests tasks were incorrectly configured, making their resolution synchronous. This means that resolving tasks in the SDK event handlers (which manage network state changes) could prevent them to finish in a timely fashion (or... ever) because they would synchronously trigger awaiting code

# Boyscout

* Save our standard code style directly in the solution to share it to whomever works on the project