### PR TITLE
Fix network recovery

### DIFF
--- a/Kuzzle.Tests/Offline/Query/QueryReplayerTest.cs
+++ b/Kuzzle.Tests/Offline/Query/QueryReplayerTest.cs
@@ -147,12 +147,12 @@ namespace Kuzzle.Tests.Offline.Query {
       testableOfflineManager.MaxQueueSize = -1;
       queryReplayer.Lock = false;
 
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foo', action: 'bar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'bar', action: 'foor'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foobar', action: 'foobar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'barfoo', action: 'foobar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foobar', action: 'barfoo'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'barfoo', action: 'barfoo'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '1', controller: 'foo', action: 'bar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '2', controller: 'bar', action: 'foor'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '3', controller: 'foobar', action: 'foobar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '4', controller: 'barfoo', action: 'foobar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '5', controller: 'foobar', action: 'barfoo'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '6', controller: 'barfoo', action: 'barfoo'}")));
 
       Assert.Equal(6, queryReplayer.Count);
 
@@ -168,12 +168,12 @@ namespace Kuzzle.Tests.Offline.Query {
       testableOfflineManager.MaxQueueSize = -1;
       queryReplayer.Lock = false;
 
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foo', action: 'bar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'bar', action: 'foor'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foobar', action: 'foobar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'barfoo', action: 'foobar'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'foobar', action: 'barfoo'}")));
-      Assert.True(queryReplayer.Enqueue(JObject.Parse("{controller: 'barfoo', action: 'barfoo'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '1', controller: 'foo', action: 'bar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '2', controller: 'bar', action: 'foor'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '3', controller: 'foobar', action: 'foobar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '4', controller: 'barfoo', action: 'foobar'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '5', controller: 'foobar', action: 'barfoo'}")));
+      Assert.True(queryReplayer.Enqueue(JObject.Parse("{requestId: '6', controller: 'barfoo', action: 'barfoo'}")));
 
       Assert.Equal(6, queryReplayer.Count);
 

--- a/Kuzzle/Kuzzle.csproj
+++ b/Kuzzle/Kuzzle.csproj
@@ -46,6 +46,10 @@
     <MonoDevelop>
       <Properties>
         <Deployment.LinuxDeployData generatePcFile="False" />
+        <Policies>
+          <TextStylePolicy RemoveTrailingWhitespace="True" NoTabsAfterNonTabs="False" EolMarker="Native" FileWidth="80" TabWidth="2" TabsToSpaces="True" IndentWidth="2" scope="text/x-csharp" />
+          <CSharpFormattingPolicy IndentBlock="True" IndentBraces="False" IndentSwitchSection="True" IndentSwitchCaseSection="True" LabelPositioning="OneLess" NewLineForElse="True" NewLineForCatch="True" NewLineForFinally="True" NewLineForMembersInObjectInit="True" NewLineForMembersInAnonymousTypes="True" NewLineForClausesInQuery="True" SpaceWithinMethodDeclarationParenthesis="False" SpaceBetweenEmptyMethodDeclarationParentheses="False" SpaceAfterMethodCallName="False" SpaceWithinMethodCallParentheses="False" SpaceBetweenEmptyMethodCallParentheses="False" SpaceAfterControlFlowStatementKeyword="True" SpaceWithinExpressionParentheses="False" SpaceWithinCastParentheses="False" SpaceWithinOtherParentheses="False" SpaceAfterCast="False" SpacesIgnoreAroundVariableDeclaration="False" SpaceBeforeOpenSquareBracket="False" SpaceBetweenEmptySquareBrackets="False" SpaceWithinSquareBrackets="False" SpaceAfterColonInBaseTypeDeclaration="True" SpaceAfterComma="True" SpaceAfterDot="False" SpaceAfterSemicolonsInForStatement="True" SpaceBeforeColonInBaseTypeDeclaration="True" SpaceBeforeComma="False" SpaceBeforeDot="False" SpaceBeforeSemicolonsInForStatement="False" SpacingAroundBinaryOperator="Single" WrappingPreserveSingleLine="True" WrappingKeepStatementsOnSingleLine="True" PlaceSystemDirectiveFirst="True" NewLinesForBracesInTypes="False" NewLinesForBracesInMethods="False" NewLinesForBracesInProperties="False" NewLinesForBracesInAccessors="False" NewLinesForBracesInAnonymousMethods="False" NewLinesForBracesInControlBlocks="False" NewLinesForBracesInAnonymousTypes="False" NewLinesForBracesInObjectCollectionArrayInitializers="False" NewLinesForBracesInLambdaExpressionBody="False" SpacingAfterMethodDeclarationName="True" scope="text/x-csharp" />
+        </Policies>
       </Properties>
     </MonoDevelop>
   </ProjectExtensions>

--- a/Kuzzle/Offline/OfflineManager.cs
+++ b/Kuzzle/Offline/OfflineManager.cs
@@ -226,7 +226,6 @@ namespace KuzzleSdk.API.Offline {
 
     internal void StateChangeListener(object sender, ProtocolState state) {
       if (state == ProtocolState.Open && previousState == ProtocolState.Reconnecting) {
-
         kuzzle.GetEventHandler().DispatchReconnected();
 
         Task.Run(async () => {
@@ -235,6 +234,7 @@ namespace KuzzleSdk.API.Offline {
         });
 
       }
+
       previousState = state;
     }
 


### PR DESCRIPTION
# Description

Fix a number of problems when handling disconnections, and with asynchronous tasks in general.


## Network disconnection

When `AbstractProtocol.AutoRecover` is set to true:

* requests sent through the network would never be resolved when the connection is lost before they receive a response. This means that clients awaiting for a response would freeze forever. With this PR, those tasks are correctly rejected with a `ConnectionLost` exception (we cannot queue them: as far as the SDK is concerned, it cannot know if these requests were received and processed by Kuzzle or not)
* there was a race condition when triggering the threaded recovering process where, in rare cases, 2 reconnection attempts would run in parallel, doubling the number of opened sockets

## Asynchronous tasks

* Race conditions could occur and corrupt the requests cache, or freeze the SDK because of an unhandled exception, because of an incorrect use of `lock` (this keyword has no impact when multiple accesses are made to the same "locked" object within the same thread) => semaphores are now used to circumvent the problem
* Requests tasks were incorrectly configured, making their resolution synchronous. This means that resolving tasks in the SDK event handlers (which manage network state changes) could prevent them to finish in a timely fashion (or... ever) because they would synchronously trigger awaiting code

# Boyscout

* Save our standard code style directly in the solution to share it to whomever works on the project