### PR TITLE
Add new auth|security:checkRights action

### DIFF
--- a/Kuzzle.Tests/API/Controllers/AuthControllerTest.cs
+++ b/Kuzzle.Tests/API/Controllers/AuthControllerTest.cs
@@ -22,6 +22,28 @@ namespace Kuzzle.Tests.API.Controllers {
     }
 
     [Fact]
+    public async void CheckRightsAsyncTest() {
+      JObject requestPayload = new JObject { 
+        { "controller", "server" }, 
+        { "action", "info" } 
+      };
+
+      _api.SetResult(@"{result: {allowed: true}}");
+
+      bool allowed = await _authController.CheckRightsAsync(requestPayload);
+
+      _api.Verify(new JObject {
+        { "controller", "auth" },
+        { "action", "checkRights" },
+        { "body", requestPayload } 
+      });
+
+      Assert.Equal<bool>(
+        true,
+        allowed);
+    }
+
+    [Fact]
     public async void CheckTokenAsyncTest() {
       string token = "foobar";
 

--- a/Kuzzle.Tests/API/Controllers/AuthControllerTest.cs
+++ b/Kuzzle.Tests/API/Controllers/AuthControllerTest.cs
@@ -38,9 +38,7 @@ namespace Kuzzle.Tests.API.Controllers {
         { "body", requestPayload } 
       });
 
-      Assert.Equal<bool>(
-        true,
-        allowed);
+      Assert.True(allowed);
     }
 
     [Fact]

--- a/Kuzzle/API/Controllers/AuthController.cs
+++ b/Kuzzle/API/Controllers/AuthController.cs
@@ -16,6 +16,20 @@ namespace KuzzleSdk.API.Controllers {
     internal AuthController(IKuzzleApi api) : base(api) { }
 
     /// <summary>
+    /// Checks if the provided API request can be executed by this network
+    /// connection, using the current authentication information.
+    /// </summary>
+    public async Task<bool> CheckRightsAsync(JObject requestPayload) {
+      Response response = await api.QueryAsync(new JObject {
+        { "controller", "auth" },
+        { "action", "checkRights" },
+        { "body", requestPayload },
+      });
+
+      return (bool)response.Result["allowed"];
+    }
+
+    /// <summary>
     /// Checks the validity of an authentication token.
     /// </summary>
     public async Task<JObject> CheckTokenAsync(string token) {

--- a/doc/2/controllers/auth/check-rights/index.md
+++ b/doc/2/controllers/auth/check-rights/index.md
@@ -1,0 +1,37 @@
+---
+code: true
+type: page
+title: CheckRightsAsync
+description: Checks if the provided API request can be executed by this network connection, using the current authentication information.
+---
+
+# CheckRightsAsync
+
+Checks if the provided API request can be executed by this network connection, using the current authentication information.
+
+## Arguments
+
+```csharp
+public async Task<bool> CheckRightsAsync(JObject requestPayload);
+```
+
+| Argument         | Type               | Description                                                                |
+| ---------------- | ------------------ | -------------------------------------------------------------------------- |
+| `requestPayload` | <pre>JObject</pre> | A JSON Object containing at least the `controller` and `action` properties |
+
+## Return
+
+A JObject which has the following properties:
+
+| Property  | Type            | Description                                                                   |
+| --------- | --------------- | ----------------------------------------------------------------------------- |
+| `allowed` | <pre>bool</pre> | a boolean telling whether the provided request would have been allowed or not |
+
+## Exceptions
+
+Throws a `KuzzleException` if there is an error. See how to [handle error](/sdk/csharp/2/essentials/error-handling).
+
+
+## Usage
+
+<<< ./snippets/check-rigths.cs

--- a/doc/2/controllers/auth/check-rights/index.md
+++ b/doc/2/controllers/auth/check-rights/index.md
@@ -21,11 +21,7 @@ public async Task<bool> CheckRightsAsync(JObject requestPayload);
 
 ## Return
 
-A JObject which has the following properties:
-
-| Property  | Type            | Description                                                                   |
-| --------- | --------------- | ----------------------------------------------------------------------------- |
-| `allowed` | <pre>bool</pre> | a boolean telling whether the provided request would have been allowed or not |
+A boolean telling whether the provided request would have been allowed or not
 
 ## Exceptions
 

--- a/doc/2/controllers/auth/check-rights/snippets/check-rights.cs
+++ b/doc/2/controllers/auth/check-rights/snippets/check-rights.cs
@@ -1,0 +1,21 @@
+try {
+  JObject response = await kuzzle.Auth.LoginAsync(
+    "local",
+    JObject.Parse("{username: 'foo', password: 'bar'}"));
+
+  JObject requestPayload = new JObject {
+    { "controller", "server"},
+    { "action", "info" }
+  };
+
+  JObject res = await kuzzle.Auth.CheckRightsAsync(requestPayload);
+
+  Console.WriteLine(res.ToString(Formatting.None));
+  /*
+  {
+    "allowed": true,
+  }
+  */
+} catch (KuzzleException e) {
+  Console.WriteLine(e);
+}

--- a/doc/2/controllers/auth/check-rights/snippets/check-rights.cs
+++ b/doc/2/controllers/auth/check-rights/snippets/check-rights.cs
@@ -8,13 +8,11 @@ try {
     { "action", "info" }
   };
 
-  JObject res = await kuzzle.Auth.CheckRightsAsync(requestPayload);
+  bool allowed = await kuzzle.Auth.CheckRightsAsync(requestPayload);
 
-  Console.WriteLine(res.ToString(Formatting.None));
+  Console.WriteLine(allowed);
   /*
-  {
-    "allowed": true,
-  }
+    true
   */
 } catch (KuzzleException e) {
   Console.WriteLine(e);

--- a/doc/2/controllers/auth/check-rights/snippets/check-rights.test.yml
+++ b/doc/2/controllers/auth/check-rights/snippets/check-rights.test.yml
@@ -1,0 +1,7 @@
+name: Auth#CheckTokenAsync
+description: Checks an authentication token's validity.
+hooks:
+  before: curl -X POST kuzzle:7512/users/foo/_create -H "Content-Type:application/json" --data '{"content":{"profileIds":["default"]},"credentials":{"local":{"username":"foo","password":"bar"}}}'
+  after: curl -X DELETE kuzzle:7512/users/foo
+template: default
+expected: ^{"expiresAt":[0-9]+,"kuid":"[a-z]+","valid":(true|false)}

--- a/doc/2/controllers/auth/check-rights/snippets/check-rights.test.yml
+++ b/doc/2/controllers/auth/check-rights/snippets/check-rights.test.yml
@@ -4,4 +4,4 @@ hooks:
   before: curl -X POST kuzzle:7512/users/foo/_create -H "Content-Type:application/json" --data '{"content":{"profileIds":["default"]},"credentials":{"local":{"username":"foo","password":"bar"}}}'
   after: curl -X DELETE kuzzle:7512/users/foo
 template: default
-expected: ^{"expiresAt":[0-9]+,"kuid":"[a-z]+","valid":(true|false)}
+expected: ^true

--- a/doc/2/controllers/auth/check-rights/snippets/check-rights.test.yml
+++ b/doc/2/controllers/auth/check-rights/snippets/check-rights.test.yml
@@ -1,7 +1,7 @@
-name: Auth#CheckTokenAsync
-description: Checks an authentication token's validity.
+name: Auth#CheckRightsAsync
+description: Checks if the provided API request can be executed by this network connection, using the current authentication information.
 hooks:
   before: curl -X POST kuzzle:7512/users/foo/_create -H "Content-Type:application/json" --data '{"content":{"profileIds":["default"]},"credentials":{"local":{"username":"foo","password":"bar"}}}'
   after: curl -X DELETE kuzzle:7512/users/foo
 template: default
-expected: True
+expected: "True"

--- a/doc/2/controllers/auth/check-rights/snippets/check-rights.test.yml
+++ b/doc/2/controllers/auth/check-rights/snippets/check-rights.test.yml
@@ -4,4 +4,4 @@ hooks:
   before: curl -X POST kuzzle:7512/users/foo/_create -H "Content-Type:application/json" --data '{"content":{"profileIds":["default"]},"credentials":{"local":{"username":"foo","password":"bar"}}}'
   after: curl -X DELETE kuzzle:7512/users/foo
 template: default
-expected: ^true
+expected: True


### PR DESCRIPTION
## What does this PR do ?
Close #71 
- [x] Add the new `auth:checkRights` Kuzzle API action to the supported AuthController methods
- [ ] Add the new `security:checkRights` Kuzzle API action to the supported SecurityController methods

### How should this be manually tested?

You could check the documentation functional tests or create your own testing C# progam using this boilerplate:
```cs
#r "Kuzzle.dll"
using System;
using System.Threading;
using System.Threading.Tasks;
using KuzzleSdk;
using KuzzleSdk.Exceptions;
using KuzzleSdk.Protocol;
using static KuzzleSdk.API.Controllers.RealtimeController;
using Newtonsoft.Json.Linq;
using Newtonsoft.Json;
using Newtonsoft.Json.Linq;
using KuzzleSdk.Exceptions;
using KuzzleSdk.API.Options;
using KuzzleSdk.API.DataObjects;
using KuzzleSdk.API;

WebSocket socket = new WebSocket(new Uri("ws://kuzzle:7512"));
KuzzleSdk.Kuzzle kuzzle = new KuzzleSdk.Kuzzle(socket);

kuzzle.ConnectAsync(CancellationToken.None).Wait()

try {
  JObject response = await kuzzle.Auth.LoginAsync(
    "local",
    JObject.Parse("{username: 'foo', password: 'bar'}"));

  JObject requestPayload = new JObject {
    { "controller", "server"},
    { "action", "info" }
  };

  JObject res = await kuzzle.Auth.CheckRightsAsync(requestPayload);

  Console.WriteLine(res.ToString(Formatting.None));
  /*
  {
    "allowed": true,
  }
  */
} catch (KuzzleException e) {
  Console.WriteLine(e);
}
```

Do not hesitate to play with the `requestPayload` value to test several API actions

